### PR TITLE
`nixos-rebuild build-vm` includes host /etc/ssh

### DIFF
--- a/src/configuration.nix
+++ b/src/configuration.nix
@@ -49,4 +49,13 @@ in
 
   time.timeZone = "America/Chicago";
   system.stateVersion = "24.11";
+
+
+  virtualisation.vmVariant.virtualisation.sharedDirectories = {
+    secrets = {
+      source = "/etc/ssh";
+      target = "/etc/ssh";
+      securityModel = "passthrough";
+    };
+  };
 }


### PR DESCRIPTION
Allows secrets to be accessed via host's ssh key.